### PR TITLE
Nerfed Meteorite Staff

### DIFF
--- a/Items/MeteoriteStaff.cs
+++ b/Items/MeteoriteStaff.cs
@@ -18,7 +18,7 @@ namespace DubNation.Items
 
 		public override void SetDefaults()
 		{
-			item.damage = 34;
+			item.damage = 16;
 			item.width = 40;
 			item.height = 40;
 			item.useTime = 36;


### PR DESCRIPTION
Meteorite Staff was a little to op, set the damage down to 16 to try to combat a nerf.